### PR TITLE
Add Public Water Systems

### DIFF
--- a/namespaces/ref/pws/README.md
+++ b/namespaces/ref/pws/README.md
@@ -1,0 +1,25 @@
+ref/pws
+===
+
+Homepage:
+* https://github.com/internetofwater/geoconnex.us/tree/master/namespaces/ref/
+
+This is a reference collection of Public Water Systems. These features should be considered community cataloging features and can be referenced as such. 
+
+The current implementation creating these ids and landing-content is in: https://github.com/ksonda/geoconnex_prep and hosted on
+https://info.geoconnex.us/collections/pws.
+
+The landing-content is based on Service Area Boundaries where available, which is currently:
+
+ - CA
+ - NC
+ - NJ
+ - PA
+ - TX
+
+Landing-content for everywhere else is based on the centroid of the state in which the water sysstem is.
+
+with gpkg source for the landing content is available [here.]https://www.hydroshare.org/resource/4a22e88e689949afa1cf71ae009eaf1b/data/contents/pws.gpkg)
+
+Contacts: 
+* Creator: <kyle.onda@duke.edu>

--- a/namespaces/ref/pws/README.md
+++ b/namespaces/ref/pws/README.md
@@ -19,7 +19,7 @@ The landing-content is based on Service Area Boundaries where available, which i
 
 Landing-content for everywhere else is based on the centroid of the state in which the water sysstem is.
 
-with gpkg source for the landing content is available [here.]https://www.hydroshare.org/resource/4a22e88e689949afa1cf71ae009eaf1b/data/contents/pws.gpkg)
+The .gpkg source for the landing content is available [here.](https://www.hydroshare.org/resource/4a22e88e689949afa1cf71ae009eaf1b/data/contents/pws.gpkg)
 
 Contacts: 
 * Creator: <kyle.onda@duke.edu>

--- a/namespaces/ref/pws/README.md
+++ b/namespaces/ref/pws/README.md
@@ -16,8 +16,9 @@ The landing-content is based on Service Area Boundaries where available, which i
  - NJ
  - PA
  - TX
+ 
 
-Landing-content for everywhere else is based on the centroid of the state in which the water sysstem is.
+Landing-content for everywhere else is based on the Census Place boundary if EPA SDWIS sepcifies the "CITY SERVED" and this name could be matched to the U.S. Census Places. If no such match was available, the centroid of the state in which the water system is.
 
 The .gpkg source for the landing content is available [here.](https://www.hydroshare.org/resource/4a22e88e689949afa1cf71ae009eaf1b/data/contents/pws.gpkg)
 

--- a/pygeoapi/pygeoapi.config.yml
+++ b/pygeoapi/pygeoapi.config.yml
@@ -491,6 +491,7 @@ resources:
             - NAME: https://schema.org/name
             - ST_uri: https://schema.org/geoWithin
             - SDWIS: https://schema.org/subjectOf
+            - PROVIDER: https://schema.org/isBasedOn
         links: 
             - type: application/html
               rel: canonical

--- a/pygeoapi/pygeoapi.config.yml
+++ b/pygeoapi/pygeoapi.config.yml
@@ -492,6 +492,7 @@ resources:
             - ST_uri: https://schema.org/geoWithin
             - SDWIS: https://schema.org/subjectOf
             - PROVIDER: https://schema.org/isBasedOn
+            - CITY_SERVED_uri: https://schema.org/geoIntersects
         links: 
             - type: application/html
               rel: canonical

--- a/pygeoapi/pygeoapi.config.yml
+++ b/pygeoapi/pygeoapi.config.yml
@@ -480,3 +480,33 @@ resources:
             id_field: GEOID
             table: places
             uri_field: uri
+    pws:
+        type: collection
+        title: Public Water Systems
+        description: U.S. Public Water Systems
+        uri_stem: https://geoconnex.us/ref/pws/
+        keywords:
+            - Public Water Systems
+        context:
+            - NAME: https://schema.org/name
+            - ST_uri: https://schema.org/geoWithin
+            - SDWIS: https://schema.org/subjectOf
+        links: 
+            - type: application/html
+              rel: canonical
+              title: EPA PWSID List source
+              href: https://echo.epa.gov/tools/data-downloads/sdwa-download-summary
+              hreflang: en-US
+        extents:
+            spatial:
+                bbox: [-170,15,-51,72]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: null
+                end: null
+        provider:
+            name: SQLiteGPKG
+            data: /ext_data/pws.gpkg
+            id_field: PWSID
+            table: pws
+            uri_field: uri


### PR DESCRIPTION
This pull request contains the following changes:

Have added PIDs for all Public Water Systems identified in [USEPA SDWIS](https://echo.epa.gov/tools/data-downloads/sdwa-download-summary). These redirect to reference features at [https://info.geoconnex.us/collections/pws](https://info.geoconnex.us/collections/pws). These reference features have one of three types of geometry:

1. If from CA, NJ, PA, NC. or TX, the geometries are the actual Water Service Area boundaries created or aggregated by state regulators

2. If the SDWIS data file identified the CITY_SERVED by the PWS, then the geometry is the same as the corresponding Census Place Geography as represented by https://info.geoconnex.us/collections/places/items/{}

3. If neither of the above were available the geometry is set to the centroid of the State the water system is within.

Each feature includes the follwoing links:

a subjectOf link to the EPA SDWIS page.
a geoWithin link to the relevant https://geoconnex.us/ref/states/{}
a geoIntersects link to the relevant https://geoconnex.us/ref/places/{} if available

Code at https://github.com/ksonda/geoconnex_prep/tree/master/pws