### PR TITLE
Postgis name patch

### DIFF
--- a/pygeoapi/pygeoapi-skin-dashboard/templates/jsonld/mainstems.jsonld
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/jsonld/mainstems.jsonld
@@ -12,19 +12,19 @@
                 "@id": "schema:supersededBy",
                 "@type": "@id"
             },   
-            "head_nhdpv2_COMID": {
+            "head_nhdpv2_comid": {
                 "@id": "wiki:Property:P885",
                 "@type": "@id"
             },
-            "outlet_nhdpv2_COMID": {
+            "outlet_nhdpv2_comid": {
                 "@id": "wiki:Property:P403",
                 "@type": "@id"
             },
-            "head_nhdpv2HUC12": {
+            "head_nhdpv2huc12": {
                 "@id": "wiki:Property:P885",
                 "@type": "@id"
             },
-            "outlet_nhdpv2HUC12": {
+            "outlet_nhdpv2huc12": {
                 "@id": "wiki:Property:P403",
                 "@type": "@id"
             },
@@ -54,29 +54,29 @@
     {% if data.encompassing_mainstem_basins %}
     "encompassing_mainstem_basin": {{ data.encompassing_mainstem_basins.replace("'", '"') }},
     {% endif %}
-    "head_nhdpv2_COMID": "{{ data.head_nhdpv2_COMID }}",
-    "outlet_nhdpv2_COMID": "{{ data.outlet_nhdpv2_COMID }}",
-    {% if data.head_nhdpv2HUC12 %}
-    "head_nhdpv2HUC12": "{{ data.head_nhdpv2HUC12 }}",
+    "head_nhdpv2_comid: "{{ data.head_nhdpv2_comid }}",
+    "outlet_nhdpv2_comid": "{{ data.outlet_nhdpv2_comid }}",
+    {% if data.head_nhdpv2huc12 %}
+    "head_nhdpv2huc12": "{{ data.head_nhdpv2huc12 }}",
     {% endif %} 
-    {% if data.outlet_nhdpv2HUC12 %}
-    "outlet_nhdpv2HUC12": "{{ data.outlet_nhdpv2HUC12 }}",
+    {% if data.outlet_nhdpv2huc12 %}
+    "outlet_nhdpv2huc12": "{{ data.outlet_nhdpv2huc12 }}",
     {% endif %} 
     "lengthkm": "{{ data.lengthkm }}",
     {% if data.outlet_drainagearea %}
     "outlet_drainagearea_sqkm": "{{ data.outlet_drainagearea }}",
     {% endif %} 
-    {% if data.head_rf1ID %}
-    "head_rf1ID": "{{ data.head_rf1ID }}",
-    "outlet_rf1ID": "{{ data.outlet_rf1ID }}",
+    {% if data.head_rf1id %}
+    "head_rf1id": "{{ data.head_rf1id }}",
+    "outlet_rf1id": "{{ data.outlet_rf1id }}",
     {% endif %}
-    {% if data.head_rf1ID %}
-    "head_nhdpv1_COMID": "{{ data.head_nhdpv1_COMID }}",
-    "outlet_nhdpv1_COMID": "{{ data.outlet_nhdpv1_COMID }}",
+    {% if data.head_rf1id %}
+    "head_nhdpv1_comid": "{{ data.head_nhdpv1_comid }}",
+    "outlet_nhdpv1_comid": "{{ data.outlet_nhdpv1_comid }}",
     {% endif %}
-    {% if data.head_latestHUC12 %}
-    "head_latestHUC12": "{{ data.head_latestHUC12 }}",
-    "outlet_latestHUC12": "{{ data.outlet_latestHUC12 }}",
+    {% if data.head_latesthuc12 %}
+    "head_latesthuc12": "{{ data.head_latesthuc12 }}",
+    "outlet_latesthuc12": "{{ data.outlet_latesthuc12 }}",
     {% endif %}
     {% if data.new_mainstemid %}
     "superseded_by_mainstem": {{ data.new_mainstemid.replace("'", '"') }},

--- a/pygeoapi/pygeoapi-skin-dashboard/templates/jsonld/ref-gages.jsonld
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/jsonld/ref-gages.jsonld
@@ -42,23 +42,23 @@
 {% if data.provider %}
     "provider": "{{ data.provider }}",
 {% endif %} 
-{% if (data.nhdpv2_REACHCODE or data.mainstem_uri) %}    
+{% if (data.nhdpv2_reachcode or data.mainstem_uri) %}    
 	"hyf:referencedPosition":   
     [
-{% if data.nhdpv2_REACHCODE %}  
+{% if data.nhdpv2_reachcode %}  
 		{
 			"hyf:HY_IndirectPosition": {
-{% if data.nhdpv2_REACH_measure is not none %} 
+{% if data.nhdpv2_reach_measure is not none %} 
 				"hyf:distanceExpression": {
 					"hyf:HY_DistanceFromReferent": { 
-						"hyf:interpolative": {{ data.nhdpv2_REACH_measure }}
+						"hyf:interpolative": {{ data.nhdpv2_reach_measure }}
 					}
 				},
 				"hyf:distanceDescription": {
 					"hyf:HY_DistanceDescription": "upstream"
 				},
 {% endif %} 
-				"hyf:linearElement": "https://geoconnex.us/nhdplusv2/reachcode/{{ data.nhdpv2_REACHCODE }}"
+				"hyf:linearElement": "https://geoconnex.us/nhdplusv2/reachcode/{{ data.nhdpv2_reachcode }}"
 			}
 		}
 {% if data.mainstem_uri %} 

--- a/pygeoapi/pygeoapi.config.yml
+++ b/pygeoapi/pygeoapi.config.yml
@@ -89,7 +89,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   gnis_url:
                       "@id": schema:subjectOf
                       "@type": "@id"
@@ -127,7 +127,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   gnis_url:
                       "@id": schema:subjectOf
                       "@type": "@id"
@@ -155,7 +155,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   gnis_url:
                       "@id": schema:subjectOf
                       "@type": "@id"
@@ -183,7 +183,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   gnis_url:
                       "@id": schema:subjectOf
                       "@type": "@id"
@@ -211,7 +211,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   gnis_url:
                       "@id": schema:subjectOf
                       "@type": "@id"
@@ -240,8 +240,8 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  AQ_NAME: schema:name
-                  LINK:
+                  aq_name: schema:name
+                  link:
                       "@id": schema:subjectOf
                       "@type": "@id"
                   sameas:
@@ -283,7 +283,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  AQ_NAME: schema:name
+                  aq_name: schema:name
                   sameas:
                       "@id": schema:sameAs
                       "@type": "@id"
@@ -319,7 +319,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  SHR: schema:name
+                  shr: schema:name
         links:
             - type: application/html
               rel: canonical
@@ -403,7 +403,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   census_profile:
                       "@id": schema:subjectOf
                       "@type": "@id"
@@ -437,7 +437,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   census_profile:
                       "@id": schema:subjectOf
                       "@type": "@id"
@@ -472,7 +472,7 @@ resources:
             - Census
         linked-data:
             context:
-                - NAME: https://schema.org/name
+                - name: https://schema.org/name
         links:
             - type: application/html
               rel: canonical
@@ -499,7 +499,7 @@ resources:
             - Census
         linked-data:
             context:
-                - NAME: https://schema.org/name
+                - name: https://schema.org/name
         links:
             - type: application/html
               rel: canonical
@@ -524,7 +524,7 @@ resources:
             - Census
         linked-data:
             context:
-                - NAME10: https://schema.org/name
+                - name10: https://schema.org/name
         links:
             - type: application/html
               rel: canonical
@@ -555,7 +555,7 @@ resources:
         linked-data:
             context:
                 - schema: https://schema.org/
-                  NAME: schema:name
+                  name: schema:name
                   census_profile:
                       "@id": schema:subjectOf
                       "@type": "@id"


### PR DESCRIPTION
changes all jsonld configs in pygeoapi.config.yml and jsonld templates to lower case to deal with postgres lower case field names. Addresses #178 