### PR TITLE
Safe escape name and description

### DIFF
--- a/pygeoapi/pygeoapi-skin-dashboard/templates/jsonld/ref-gages.jsonld
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/jsonld/ref-gages.jsonld
@@ -32,8 +32,8 @@
 		"https://www.opengis.net/def/schema/hy_features/hyf/HY_HydrometricFeature",
 		"https://www.opengis.net/def/schema/hy_features/hyf/HY_HydroLocation"
 	],
-    "name": "{{ data.name }}",
-    "description": "{{ data.description }}",
+    "name": "{{ data.name | safe  }}",
+    "description": "{{ data.description | safe }}",
 {% if data.subjectOf %}  
     "subjectOf": {
 	    "schema:url": "{{ data.subjectOf }}"


### PR DESCRIPTION
Noticed a couple gages are throwing 500's ([1124690](https://reference-features.internetofwater.app/collections/gages/items/1124690?f=jsonld), [1124656](https://reference-features.internetofwater.app/collections/gages/items/1124656?f=jsonld)). Their json representations share special characters so I am hoping (untested) safe escaping the strings will help.