### PR TITLE
Add intersection process and update skin dashboard templates

### DIFF
--- a/pygeoapi/pygeoapi-skin-dashboard/static/css/default.css
+++ b/pygeoapi/pygeoapi-skin-dashboard/static/css/default.css
@@ -11,7 +11,7 @@ main {
 }
 
 .crumbs {
-    background-color:rgb(230, 230, 230);
+    padding-left: 12px;
     padding: 6px;
 }
 
@@ -46,4 +46,19 @@ main {
 
 table:not(.horizontal) {
     max-height: none;
+}
+
+@media (max-width: 767px) {
+    .sidebar {
+        display: none;
+        visibility: hidden;
+        width: 0px;
+    }
+    .crumbs {
+        display: none !important;
+    }
+    a.nav-link {
+        margin: auto;
+        padding: 4px !important;
+    }
 }

--- a/pygeoapi/pygeoapi-skin-dashboard/static/css/sb.css
+++ b/pygeoapi/pygeoapi-skin-dashboard/static/css/sb.css
@@ -10284,7 +10284,6 @@ a:focus {
 }
 
 .sidebar {
-  width: 6.5rem;
   min-height: 100vh;
 }
 

--- a/pygeoapi/pygeoapi-skin-dashboard/templates/_base.html
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/_base.html
@@ -29,18 +29,41 @@
 
 <body id="page-top">
 
+  <div id="appbar">
+    <!-- Topbar -->
+    <nav class="navbar navbar-expand navbar-light bg-white topbar static-top shadow">
+
+      <!-- Sidebar Toggle (Topbar) -->
+      <button id="sidebarToggleTop" class="btn btn-link rounded-circle mr-3" onclick="toggleNav()">
+        <i class="fa fa-bars"></i>
+      </button>
+
+      <!-- Topbar - Brand -->
+      <a class="sidebar-brand d-flex align-items-center justify-content-center" style="background-color:white"
+      href="{{ config['server']['url'] }}" class="logo" role="button">
+        <img src="https://raw.githubusercontent.com/internetofwater/geoconnex.us/master/pygeoapi/pygeoapi-skin-dashboard/static/img/logo.png" title="{{ config['metadata']['identification']['title'] }}" style="height:40px;vertical-align: middle;" /></a>
+      </a>
+
+      <div class="crumbs">
+        {% block crumbs %}
+        {% endblock %}
+      </div>
+
+      <!-- Topbar Navbar -->
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item"><a class="nav-link" href="{{ data['links'] | map(rel='self') | attr('href') }}?f=json">JSON</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ data['links'] | map(rel='self') | attr('href') }}?f=jsonld">JSON-LD</a></li>
+      </ul>
+
+    </nav>
+    <!-- End of Topbar -->
+  </div>
+
   <!-- Page Wrapper -->
   <div id="wrapper">
 
       <!-- Sidebar -->
       <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-        <!-- Sidebar - Brand -->
-        <a class="sidebar-brand d-flex align-items-center justify-content-center" style="background-color:white"
-          href="{{ config['server']['url'] }}" class="logo" role="button">
-            <img src="https://raw.githubusercontent.com/internetofwater/geoconnex.us/master/pygeoapi/pygeoapi-skin-dashboard/static/img/logo.png" title="{{ config['metadata']['identification']['title'] }}" style="height:40px;vertical-align: middle;" /></a>
-
-        </a>
 
         <!-- Divider -->
         <hr class="sidebar-divider my-0">
@@ -74,14 +97,12 @@
           </li>
         {% endif %}
 
-        {% if data['processes'] %}
-          <!-- Nav Item -->
-          <li class="nav-item">
-          <a class="nav-link" href="{{ config['server']['url'] }}/processes">
-              <i class="fas fa-fw fa-wrench"></i>
-            Processes</a>
-          </li>
-        {% endif %}
+        <!-- Nav Item -->
+        <li class="nav-item">
+        <a class="nav-link" href="{{ config['server']['url'] }}/processes">
+            <i class="fas fa-fw fa-wrench"></i>
+          Processes</a>
+        </li>
 
         <!-- Divider -->
         <hr class="sidebar-divider">
@@ -113,31 +134,8 @@
           <!-- Main Content -->
           <div id="content">
 
-              <!-- Topbar -->
-              <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-
-                  <!-- Sidebar Toggle (Topbar) -->
-                  <button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3">
-                      <i class="fa fa-bars"></i>
-                  </button>
-
-                  <div>
-                    {% block crumbs %}
-                    <a href="{{ config['server']['url'] }}">Home</a>
-                    {% endblock %}
-                  </div>
-
-                  <!-- Topbar Navbar -->
-                  <ul class="navbar-nav ml-auto">
-                    <li class="nav-item"><a class="nav-link" href="{{ data['links'] | map(rel='self') | attr('href') }}?f=json">JSON</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ data['links'] | map(rel='self') | attr('href') }}?f=jsonld">JSON-LD</a></li>
-                  </ul>
-
-              </nav>
-              <!-- End of Topbar -->
-
               <!-- Begin Page Content -->
-              <div class="container-fluid">
+              <div class="container-fluid pt-4">
 
                 <!-- Page Heading
                 <div class="d-sm-flex align-items-center justify-content-between mb-4">
@@ -223,8 +221,6 @@
   </div>
   <!-- End of Page Wrapper -->
 
-
-
   {% block extrafoot %}
   {% endblock %}
     <script>
@@ -243,6 +239,20 @@
         }
       };
       xhr.send();
+    </script>
+    <script>
+      function toggleNav() {
+        const nav = document.getElementById("accordionSidebar");
+        if (nav.offsetWidth === 0){
+          nav.style.width = "224px";
+          nav.style.display = "block";
+          nav.style.visibility = "visible";
+        } else {
+          nav.style.width = "0";
+          nav.style.display = "none";
+          nav.style.visibility = "hidden";
+        }
+      }
     </script>
   </body>
 </html>

--- a/pygeoapi/pygeoapi-skin-dashboard/templates/collections/collection.html
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/collections/collection.html
@@ -16,12 +16,6 @@
         <div class="col-sm">
           <h1>{{ data['title'] }}</h1>
           <p>{{ data['description'] }}</p>
-		  <ul>
-          <li>
-            <a title="{{data['links'][0]['rel'] }}" href="{{ data['links'][0]['href'] }}">
-            <span>{{ data['links'][0]['title'] }}</span> (<span>{{ data['links'][0]['type'] }}</span>)
-            </a></li>
-      </ul>
           <p>
             {% for kw in data['keywords'] %}
               <span class="badge badge-info">{{ kw }}</span>
@@ -62,6 +56,15 @@
               <a title="Display Queryables" href="{{ config['server']['url'] }}/collections/{{ data['id'] }}/queryables">
                 Display Queryables of "{{ data['title'] }}"</a></div>
           </li>
+        </ul>
+        <h3>Links</h3>
+        <ul>
+          {% for link in data['links'] %}
+              <li>
+                <a title="{{ link['rel'] }}" href="{{ link['href'] }}">
+                <span>{{ link['title'] }}</span> (<span>{{ link['type'] }}</span>)
+                </a></li>
+          {% endfor %}
         </ul>
         {% for provider in config['resources'][data['id']]['providers'] %}
           {% if 'tile' in provider['type'] %}

--- a/pygeoapi/pygeoapi-skin-dashboard/templates/collections/items/index.html
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/collections/items/index.html
@@ -1,18 +1,21 @@
 {% extends "_base.html" %}
 {% block title %}{{ super() }} {{ data['title'] }} {% endblock %}
 {% block crumbs %}{{ super() }}
-/ <a href="{{ data['collections_path'] }}">Collections</a>
+/ <a href="{{ data['collections_path'] }}">{% trans %}Collections{% endtrans %}</a>
 {% for link in data['links'] %}
   {% if link.rel == 'collection' %} /
-    <a href="{{ data['dataset_path'] }}">{{ link['title'] | truncate( 25 ) }}</a>
+    <a href="{{ data['dataset_path'] }}">{{ link['title'] | string | truncate( 25 ) }}</a>
     {% set col_title = link['title'] %}
   {% endif %}
 {% endfor %}
-/ <a href="{{ data['items_path']}}">Items</a>
+/ <a href="{{ data['items_path']}}">{% trans %}Items{% endtrans %}</a>
 {% endblock %}
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
     <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css"/>
+    <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster-src.js"></script>
 {% endblock %}
 
 {% block body %}
@@ -46,7 +49,7 @@
               <div id="limit" class="col-sm-12">
                 Limit:
                 <select id="limits">
-                  <option value="10">10 (default)</option>
+                  <option value="{{ config['server']['limit'] }}">{{ config['server']['limit'] }} ({% trans %}default{% endtrans %})</option>
                   <option value="100">100</option>
                   <option value="1000">1,000</option>
                   <option value="2000">2,000</option>
@@ -85,36 +88,62 @@
               </h6>
           </div>
           <!-- Card Body -->
-          <div>
+          <div style="overflow-x: scroll;">
+            {% set props = [] %}
             <table class="table table-striped">
               <thead>
                 <tr>
-                  <th>id</th>
-                  {% if data['title_field'] %}
-                    <th>{{ data['title_field'] }}</th>
+                  {% if data.get('uri_field') %}
+                    {% set uri_field = data.uri_field %}
+                    <th>{{ uri_field }}</th>
+                  {% elif data.get('title_field') %}
+                    {% set title_field = data.title_field %}
+                    <th>{{ title_field }}</th>
+                  {% else %}
+                    <th>id</th>
                   {% endif %}
-                  {% for k, v in data['features'][0]['properties'].items() %}
-                    {# start with id & title then take first 5 columns for table #}
-                    {% if loop.index < 5 and k != data['id_field'] and k != data['title_field'] %}
-                    <th>{{ k }}</th>
+    
+                  {% for k in data['features'][0]['properties'].keys() %}
+                    {% if k not in [data.id_field, data.title_field, data.uri_field, 'extent'] %}
+                      {% set props = props.append(k) %}
+                      <th>{{ k }}</th>
                     {% endif %}
                   {% endfor %}
-              </tr>
+                </tr>
             </thead>
             <tbody>
-              {% for ft in data['features'] %}
+              {% for ft in data.features %}
               <tr>
-                <td data-label="id"><a href="{{ ft['properties'][data['uri_field']] }}" title="{{ ft.id }}">{{ ft.id | string | truncate( 12 )  }}</a></td>
-                {% if data['title_field'] %}
-                  <td data-label="name"><a href="{{ data['items_path']}}/{{ ft['id'] }}" title="{{ ft['properties'][data['title_field']] }}">{{ ft['properties'][data['title_field']] | string | truncate( 35 ) }}</a></td>
+                {% if data.get('uri_field') %}
+                  {% set uri_field = data.uri_field %}
+                  <td data-label="{{ uri_field }}">
+                    <a href="{{ ft.properties.get(uri_field) }}" title="{{ ft.properties.get(uri_field) }}">
+                      {{ ft.properties.get(uri_field) }}
+                    </a>
+                  </td>
+                {% elif data.get('title_field') %}
+                  {% set title_field = data.title_field %}
+                  <td data-label="{{ title_field }}">
+                    <a href="{{ data.items_path }}/{{ ft['id'] }}" title="{{ ft.properties.get(title_field) }}">
+                      {{ ft.properties.get(title_field) | string | truncate( 35 ) }}
+                    </a>
+                  </td>
+                {% else %}
+                  <td data-label="id">
+                    <a href="{{ data.items_path }}/{{ ft.id }}" title="{{ ft.id }}">
+                      {{ ft.id | string | truncate( 12 )  }}
+                    </a>
+                  </td>
                 {% endif %}
-                {% for k, v in ft['properties'].items() %}
-                  {% if loop.index < 5 and k not in [data['id_field'], data['title_field'], 'extent'] %}
-                  <td data-label="{{ k }}">{{ v | string | truncate( 35 ) }}</td>
-                  {% endif %}
+
+                {% for prop in props %}
+                  <td data-label="{{ prop }}">
+                    {{ ft.properties.get(prop, '') | string | truncate( 35 ) }}
+                  </td>
                 {% endfor %}
+
               </tr>
-              {% endfor %}
+            {% endfor %}
             </tbody>
             </table>
           </div>
@@ -131,25 +160,36 @@
 
 {% block extrafoot %}
 {% if data['features'] %}
-    <script>
-    var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 5);
-    map.addLayer(new L.TileLayer(
-        '{{ config['server']['map']['url'] }}', {
-            maxZoom: 18,
-            attribution: '{{ config['server']['map']['attribution'] }}'
-        }
-    ));
-    var geojson_data = {{ data['features'] | to_json | safe }};
-    var items = new L.GeoJSON(geojson_data, {
-        onEachFeature: function (feature, layer) {
-            var url = '{{ data['items_path'] }}/' + feature.id + '?f=html';
-            var html = '<span><a href="' + url + '">' + {% if data['title_field'] %} feature['properties']['{{ data['title_field'] }}'] {% else %} feature.id {% endif %} + '</a></span>';
-            layer.bindPopup(html);
-        }
-    });
+  <script>
+  var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 5);
+  map.addLayer(new L.TileLayer(
+      '{{ config['server']['map']['url'] }}', {
+          maxZoom: 18,
+          attribution: '{{ config['server']['map']['attribution'] | safe }}'
+      }
+  ));
+  var geojson_data = {{ data['features'] | to_json | safe }};
 
-    map.addLayer(items);
-    map.fitBounds(items.getBounds());
-    </script>
+  var items = new L.GeoJSON(geojson_data, {
+      onEachFeature: function (feature, layer) {
+          var url = '{{ data['items_path'] }}/' + feature.id + '?f=html';
+          var html = '<span><a href="' + url + '">' + {% if data['title_field'] %} feature['properties']['{{ data['title_field'] }}'] {% else %} feature.id {% endif %} + '</a></span>';
+          layer.bindPopup(html);
+      }
+  });
+  {% if data['features'][0]['geometry']['type'] == 'Point' %}
+  var markers = L.markerClusterGroup({
+      disableClusteringAtZoom: 9,
+      chunkedLoading: true,
+      chunkInterval: 500,
+  });
+  markers.clearLayers().addLayer(items);
+  map.addLayer(markers);
+  {% else %}
+  map.addLayer(items);
+  {% endif %}
+
+  map.fitBounds(items.getBounds());
+  </script>
 {% endif %}
 {% endblock %}

--- a/pygeoapi/pygeoapi-skin-dashboard/templates/landing_page.html
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/landing_page.html
@@ -11,6 +11,35 @@
           <mark class="badge badge-info">{{ kw }}</mark>
         {% endfor %}
     </p>
+    {% if data['collection'] %}
+      <section id="collections">
+        <h2>{% trans %}Collections{% endtrans %}</h2>
+        <p>
+          <a href="{{ config['server']['url'] }}/collections?f=html">{% trans %}View the collections in this service{% endtrans %}</a>
+        </p>
+      </section>
+   {% endif %}
+   {% if data['processes'] %}
+    <section id="processes">
+        <h2>{% trans %}Processes{% endtrans %}</h2>
+        <p>
+          <a href="{{ config['server']['url'] }}/processes?f=html">{% trans %}View the processes in this service{% endtrans %}</a>
+        </p>
+    </section>
+    {% endif %}
+    <section id="documentation">
+      <h2>{% trans %}Documentation{% endtrans %}</h2>
+      <p>
+        <a href="https://docs.geoconnex.us/">{% trans %}Geoconnex documentation{% endtrans %}</a>
+      </p>
+      <p>
+        <a href="{{ config['server']['url'] }}/openapi?f=html">{% trans %}Swagger UI{% endtrans %}</a>
+      </p>
+      <p>
+        <a href="{{ config['server']['url'] }}/openapi?f=json">{% trans %}OpenAPI Document{% endtrans %}</a>
+      </p>
+    </section>
+
   </div>
 </div>
 {% endblock %}

--- a/pygeoapi/pygeoapi-skin-dashboard/templates/processes/process.html
+++ b/pygeoapi/pygeoapi-skin-dashboard/templates/processes/process.html
@@ -17,29 +17,29 @@
       <div class="row">
         <div class="col-sm-12 col-md-12">
           <table class="table table-striped">
-            <caption>Inputs</caption>
+            <caption>{% trans %}Inputs{% endtrans %}</caption>
             <thead>
             <tr>
-              <th>ID</th>
-              <th>Title</th>
-              <th>Data Type</th>
-              <th>Description</th>
+              <th>{% trans %}Id{% endtrans %}</th>
+              <th>{% trans %}Title{% endtrans %}</th>
+              <th>{% trans %}Data Type{% endtrans %}</th>
+              <th>{% trans %}Description{% endtrans %}</th>
             </tr>
             </thead>
             <tbody>
-              {% for input_ in data['inputs'] %}
+              {% for key, value in data['inputs'].items() %}
               <tr itemprop="parameter" itemscope>
                 <td itemprop="id" data-label="ID">
-                  {{ input_.id }}
+                  {{ key }}
                 </td>
                 <td itemprop="name" data-label="Title">
-                  {{ input_.title|striptags|truncate }}
+                  {{ value.title|striptags|truncate }}
                 </td>
-                <td itemprop="name" data-label="Title">
-                  {{ input_.input.literalDataDomain.dataType }}
+                <td itemprop="name" data-label="Data Type">
+                  {{ value.schema.type }}
                 </td>
                 <td itemprop="description" data-label="Description">
-                  {{ input_.abstract }}
+                  {{ value.description }}
                 </td>
               </tr>
               {% endfor %}
@@ -48,34 +48,34 @@
         </div>
         <div class="col-sm-12 col-md-12">
           <table class="table table-striped">
-            <caption>Outputs</caption>
+            <caption>{% trans %}Outputs{% endtrans %}</caption>
             <thead>
             <tr>
-              <th>ID</th>
-              <th>Title</th>
-              <th>Description</th>
+              <th>{% trans %}Id{% endtrans %}</th>
+              <th>{% trans %}Title{% endtrans %}</th>
+              <th>{% trans %}Description{% endtrans %}</th>
             </tr>
             </thead>
             <tbody>
-              {% for output_ in data['outputs'] %}
+              {% for key, value in data['outputs'].items() %}
               <tr itemprop="parameter" itemscope>
-                <td itemprop="id" data-label="ID">{{ output_['id'] }}</td>
-                <td itemprop="name" data-label="Title">{{ output_['title'] }}</td>
+                <td itemprop="id" data-label="ID">{{ key }}</td>
+                <td itemprop="name" data-label="Title">{{ value.title }}</td>
                 <td itemprop="description" data-label="Description">
-                  {{ output_['description'] | striptags | truncate }}
+                  {{ value.description | striptags | truncate }}
                 </td>
               </tr>
               {% endfor %}
             </tbody>
           </table>
-          <h2>Execution modes</h2>
+          <h2>{% trans %}Execution modes{% endtrans %}</h2>
           <ul>
-            {% if 'sync-execute' in data.jobControlOptions %}<li>Synchronous</li>{% endif %}
-            {% if 'async-execute' in data.jobControlOptions %}<li>Asynchronous</li>{% endif %}
+            {% if 'sync-execute' in data.jobControlOptions %}<li>{% trans %}Synchronous{% endtrans %}</li>{% endif %}
+            {% if 'async-execute' in data.jobControlOptions %}<li>{% trans %}Asynchronous{% endtrans %}</li>{% endif %}
           </ul>
-          <h2>Jobs</h2>
-          <a title="Browse jobs" href="{{config.server.url}}/processes/{{data.id}}/jobs">Browse jobs</a>
-          <h2>Links</h2>
+          <h2>{% trans %}Jobs{% endtrans %}</h2>
+          <a title="Browse jobs" href="{{config.server.url}}/jobs">{% trans %}Browse jobs{% endtrans %}</a>
+          <h2>{% trans %}Links{% endtrans %}</h2>
           <ul>
             {% for link in data['links'] %}
                 <li>

--- a/pygeoapi/pygeoapi.config.yml
+++ b/pygeoapi/pygeoapi.config.yml
@@ -660,3 +660,7 @@ resources:
               table: ref_dams
               uri_field: uri
               geom_field: geom
+    intersector:
+        type: process
+        processor:
+            name: Intersector


### PR DESCRIPTION
Add intersection OGC API - process from pygeoapi-plugins in support of https://github.com/internetofwater/geoconnex.us/issues/184. The data passed to the `pygeoapi/pygeoapi-skin-dashboard/templates/processes/process.html` jinja template has changed so I had to update the skin-dashboard template (cc: @dblodgett-usgs potentially the same issue as https://labs.waterdata.usgs.gov/api/nldi/pygeoapi/processes/nldi-flowtrace).

Also made additional updates to html templates. The differences can be seen at [the branch of this PR](https://geoconnex-us-eaxlzxprna-uc.a.run.app/) and [master](https://reference.geoconnex.us/). A mostly-exhaustive list is of changes to the htmls representations are:

- Modification of _base.html and css to slightly improve the appearance on the navigation on mobile devices.
![image](https://github.com/internetofwater/geoconnex.us/assets/40066515/9a5181fd-dc4a-4fb3-9076-af9cbb1f166a)
- Added more information to the landing page
![image](https://github.com/internetofwater/geoconnex.us/assets/40066515/d4c9268c-fa31-425f-babc-19cfb399a6db)
- Include all links in collection specific landing pages
![image](https://github.com/internetofwater/geoconnex.us/assets/40066515/b8e09c42-5679-4e82-8f02-4a5178913007)
- Load full table in /items (as implemented in https://github.com/geopython/pygeoapi/pull/1148)
![image](https://github.com/internetofwater/geoconnex.us/assets/40066515/588dbd1d-f412-41f1-9997-d60e76c72b68)
- Fix the OAProc HTML representation and implement OAProc Intersector
![image](https://github.com/internetofwater/geoconnex.us/assets/40066515/a9294931-06a1-4aab-9394-553356b1747b)

