### PR TITLE
Switch from labs.waterdata to api.water

### DIFF
--- a/demo/index.Rmd
+++ b/demo/index.Rmd
@@ -397,9 +397,9 @@ geom_site <- sf::read_sf("https://geoconnex.us/nmwdi/nmbgmr/wells/NM0028827")
 point <- sf::st_sfc(geom_site$geometry)
 geom_site <- geom_site$geometry[[1]]
 nldi_point<-nhdplusTools::discover_nhdplus_id(point)
-# nldiURL<-"DM = "https://labs.waterdata.usgs.gov/api/nldi/linked-data/nwissite/USGS-08279500/navigate/DM?distance=100"
+# nldiURL<-"DM = "https://api.water.usgs.gov/nldi/linked-data/nwissite/USGS-08279500/navigate/DM?distance=100"
 
-nldi_query <- URLencode(paste0('https://labs.waterdata.usgs.gov/api/nldi/linked-data/comid/position?f=json&coords=POINT(',geom_site[1],' ',geom_site[2],')'))
+nldi_query <- URLencode(paste0('https://api.water.usgs.gov/nldi/linked-data/comid/position?f=json&coords=POINT(',geom_site[1],' ',geom_site[2],')'))
 start <- sf::read_sf(nldi_query)
 mainstem <- sf::read_sf(paste0(start$navigation,"/DM/flowlines?distance=250"))
 
@@ -412,7 +412,7 @@ mapview::mapview(list("Downstream Mainstem"=sf::st_as_sf(sf::st_geometry(mainste
 The above code constructs the URLs to call the NLDI service directly, however there are convenience tools in [R](https://usgs-r.github.io/nhdplusTools/index.html) and [Python](https://github.com/cheginit/pynhd) to interact with the NLDI. Below we use the R package `nhdplusTools` to discover data indexed to our downstream mainstem in the NLDI. What features are available from the NLDI?
 
 ```{r, message=FALSE, warning=FALSE}
-knitr::kable(fromJSON("https://labs.waterdata.usgs.gov/api/nldi/linked-data"))
+knitr::kable(fromJSON("https://api.water.usgs.gov/nldi/linked-data/"))
 
 ```
 

--- a/namespaces/iow/links.csv
+++ b/namespaces/iow/links.csv
@@ -3,7 +3,7 @@ https://geoconnex.us/iow/homepage, https://internetofwater.org, konda@lincolnins
 https://geoconnex.us/iow/aboutus, https://internetofwater.org/who-we-are/, konda@lincolninst.edu, About us
 https://geoconnex.us/demo, https://geoconnex.internetofwater.dev/demo, konda@lincolninst.edu, geconnex demo
 https://geoconnex.us/iow/sitemap, https://reference.geoconnex.us/stac/sitemap, bwebb@lincolninst.edu, geoconnex sitemap
-https://geoconnex.us/iow/nldi, https://labs.waterdata.usgs.gov/about-nldi/index.html, konda@lincolninst.edu, nldi shortlink
+https://geoconnex.us/iow/nldi, https://waterdata.usgs.gov/blog/nldi-intro/, konda@lincolninst.edu, nldi shortlink
 https://geoconnex.us/iow/nldi/demo, https://storymaps.arcgis.com/stories/0ecb1aaf143b4e1981dbe30f38fceec5, konda@lincolninst.edu, nldi demo shortlink
 https://geoconnex.us/iow/map, https://gis.cgs.earth/portal/apps/webappviewer/index.html?id=41e8676b373344dfab9733b4d8f32837, konda@lincolninst.edu, geoconnex content map
 https://geoconnex.us/iow/cr-demo, https://lincolninstitute.maps.arcgis.com/apps/mapviewer/index.html?webmap=87f4a26d8af24e758b39ec4d137661ac,  konda@lincolninst.edu, geoconnex demo map

--- a/namespaces/nhdplusv2/comid.csv
+++ b/namespaces/nhdplusv2/comid.csv
@@ -1,2 +1,2 @@
 id,target,creator,description
-https://geoconnex.us//nhdplusv2/comid/([0-9]+).*$, https://labs.waterdata.usgs.gov/api/nldi/linked-data/comid/$1, iow, NHDPlusV2 NLDI comids
+https://geoconnex.us//nhdplusv2/comid/([0-9]+).*$, https://api.water.usgs.gov/nldi/linked-data/comid/$1, iow, NHDPlusV2 NLDI comids

--- a/namespaces/nhdplusv2/huc12pp/huc12pourpoints.csv
+++ b/namespaces/nhdplusv2/huc12pp/huc12pourpoints.csv
@@ -1,2 +1,2 @@
 id,target,creator,description
-https://geoconnex.us//nhdplusv2/huc12/([0-9]+)$, https://labs.waterdata.usgs.gov/api/nldi/linked-data/huc12pp/$1, iow, NHDPlusV2 NLDI HUC12
+https://geoconnex.us//nhdplusv2/huc12/([0-9]+)$, https://api.water.usgs.gov/nldi/linked-data/huc12pp/$1, iow, NHDPlusV2 NLDI HUC12

--- a/namespaces/nhdplusv2/reachcode.csv
+++ b/namespaces/nhdplusv2/reachcode.csv
@@ -1,2 +1,2 @@
 id,target,creator,description
-https://geoconnex.us//nhdplusv2/reachcode/([0-9]+).*$, https://labs.waterdata.usgs.gov/geoserver/wmadata/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=wmadata%3Anhdflowline_network&outputFormat=application%2Fjson&cql_filter=reachcode%20=%20%27$1%27, iow, NHDPlusV2 reachcode
+https://geoconnex.us//nhdplusv2/reachcode/([0-9]+).*$, https://api.water.usgs.gov/geoserver/wmadata/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=wmadata%3Anhdflowline_network&outputFormat=application%2Fjson&cql_filter=reachcode%20=%20%27$1%27, iow, NHDPlusV2 reachcode

--- a/namespaces/nhdplusv2/wb_comid.csv
+++ b/namespaces/nhdplusv2/wb_comid.csv
@@ -1,2 +1,2 @@
 id,target,creator,description
-https://geoconnex.us//nhdplusv2/nhdwaterbody_comid/([0-9]+).*$, https://labs.waterdata.usgs.gov/geoserver/wmadata/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=wmadata%3Anhdwaterbody&outputFormat=application%2Fjson&cql_filter=comid%20=%20%27$1%27, iow, NHDPlusV2 nhdwaterbody
+https://geoconnex.us//nhdplusv2/nhdwaterbody_comid/([0-9]+).*$, https://api.water.usgs.gov/geoserver/wmadata/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=wmadata%3Anhdwaterbody&outputFormat=application%2Fjson&cql_filter=comid%20=%20%27$1%27, iow, NHDPlusV2 nhdwaterbody


### PR DESCRIPTION
We've fully migrated our production services to api.water.usgs.gov and I'd like to update the redirects and various links in geoconnex. I think I got them all.

I was not able to rebuild the demo.html as various links are now stale in that demo. 