### PR TITLE
Best practice github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/best-practice-issue.md
+++ b/.github/ISSUE_TEMPLATE/best-practice-issue.md
@@ -1,0 +1,8 @@
+---
+name: Best Practice Issue
+title: ""
+labels: Best Practices
+about: An issue or edge case with the best practices underlying Geoconnex
+
+---
+

--- a/.github/ISSUE_TEMPLATE/best-practice-proposal.md
+++ b/.github/ISSUE_TEMPLATE/best-practice-proposal.md
@@ -1,0 +1,8 @@
+---
+name: Best Practice Proposal
+title: ""
+labels: Best Practices
+about: A proposal for new or changed best practices for future Geoconnex development
+
+---
+

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,6 +1,6 @@
 ---
 name: General geoconnex issue
-about: This is just so we have a general button
+about: Something related to a technical issue in Geoconnex
 title: "[general]"
 
 ---

--- a/.github/ISSUE_TEMPLATE/request-regex-redirect.md
+++ b/.github/ISSUE_TEMPLATE/request-regex-redirect.md
@@ -1,8 +1,8 @@
 ---
 name: Request regex redirect
-about: Describe this issue template's purpose here.
 title: "[regex redirect request]"
 labels: PID request
+about: A request to associate a regex with data in Geoconnex
 assignees: dblodgett-usgs, ksonda
 
 ---
@@ -28,14 +28,14 @@ PID pattern:
 Target pattern:
 
 ### Explanation of the kinds of expressions to match from the end of the PID pattern to the end of the target pattern.
-(e.g. 9-digit numbers, 12-charachter alphanumeric strings, specific combinations of letters & numbers & special characters)
+(e.g. 9-digit numbers, 12-character alphanumeric strings, specific combinations of letters & numbers & special characters)
 
 Expression type:
 
 ### 2-3 example target URIs
 (e.g. https://example.org/features?query=12345)
 
-target URI example:
+Target URI example:
 
 Target URI example:
 


### PR DESCRIPTION
Add a best practice issue template for both an issue or creating a new one

Fix up a few minor issues with existing templates. We don't want to have the placeholder text like `This is just so we have a general button` show up for users so changed the about text to be more meaningful

![image](https://github.com/user-attachments/assets/2aba8d7e-f034-4f3a-9eb3-5b3dbf646a07)
