### PR TITLE
Add restart condition for test yourls action

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -43,3 +43,6 @@ services:
       YOURLS_DB_HOST: ${YOURLS_DB_HOST:-mysql}
     volumes:
         - ./namespaces:/namespaces
+    depends_on: 
+      - mysql
+    restart: on-failure


### PR DESCRIPTION
- yourls action should not run until mysql is started
- if mysql is running but not fully initialized, the yourls-action will fail and throw a connection error; it should be configured to restart until it succeeds

this log below shows how it fails at first, but retries due to the new restart setting and then ends up succeeding
```

Traceback (most recent call last):
  File "/usr/local/bin/yourls-action", line 33, in <module>
    sys.exit(load_entry_point('yourls-action', 'console_scripts', 'yourls-action')())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/yourls-action/yourls_action/cli.py", line 73, in run
    urls.handle_csv(walk_path(p))
  File "/yourls-action/yourls_action/api.py", line 166, in handle_csv
    self._handle_csvs(file)
  File "/yourls-action/yourls_action/api.py", line 157, in _handle_csvs
    self.handle_csv(f)
  File "/yourls-action/yourls_action/api.py", line 173, in handle_csv
    self.post_mysql(file, chunk)
  File "/yourls-action/yourls_action/api.py", line 139, in post_mysql
    mydb, cursor = connection()
  File "/yourls-action/yourls_action/api.py", line 40, in connection
    db = mysql.connector.connect(pool_name='yourls_loader')
  File "/usr/local/lib/python3.9/site-packages/mysql/connector/pooling.py", line 309, in connect
    return _get_pooled_connection(**kwargs)
  File "/usr/local/lib/python3.9/site-packages/mysql/connector/pooling.py", line 102, in _get_pooled_connection
    return _CONNECTION_POOLS[pool_name].get_connection()
  File "/usr/local/lib/python3.9/site-packages/mysql/connector/pooling.py", line 656, in get_connection
    raise PoolError("Failed getting connection; pool exhausted") from err
mysql.connector.errors.PoolError: Failed getting connection; pool exhausted
247837 was deleted.
/namespaces/ref/dams/dams.csv
/namespaces/ref/mainstems/mainstems.csv
/namespaces/ref/gages/gages.csv
/namespaces/cdss/co_gages.csv
/namespaces/nmwdi/st/nmwdi-st.csv
```