### PR TITLE
Remove stale noaa stations

### DIFF
--- a/namespaces/wwdh/noaa_rfc/noaa_rfc.csv
+++ b/namespaces/wwdh/noaa_rfc/noaa_rfc.csv
@@ -242,9 +242,6 @@ https://geoconnex.us/wwdh/noaa_rfc/TOSM8,https://api.wwdh.internetofwater.app/co
 https://geoconnex.us/wwdh/noaa_rfc/VRGM8,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/VRGM8,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/WODW4,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/WODW4,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/YLOW4,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/YLOW4,cloftus@lincolninst.edu,NOAA River Forecast Center
-https://geoconnex.us/wwdh/noaa_rfc/BTYO3,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/BTYO3,cloftus@lincolninst.edu,NOAA River Forecast Center
-https://geoconnex.us/wwdh/noaa_rfc/WMSO3,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/WMSO3,cloftus@lincolninst.edu,NOAA River Forecast Center
-https://geoconnex.us/wwdh/noaa_rfc/KLAO3,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/KLAO3,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/FTJC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/FTJC1,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/CEGC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/CEGC1,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/DLTC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/DLTC1,cloftus@lincolninst.edu,NOAA River Forecast Center
@@ -313,10 +310,7 @@ https://geoconnex.us/wwdh/noaa_rfc/AKYC1,https://api.wwdh.internetofwater.app/co
 https://geoconnex.us/wwdh/noaa_rfc/CBAC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/CBAC1,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/ICHC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/ICHC1,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/RBBC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/RBBC1,cloftus@lincolninst.edu,NOAA River Forecast Center
-https://geoconnex.us/wwdh/noaa_rfc/CHSO3,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/CHSO3,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/SBRC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/SBRC1,cloftus@lincolninst.edu,NOAA River Forecast Center
-https://geoconnex.us/wwdh/noaa_rfc/SCNO3,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/SCNO3,cloftus@lincolninst.edu,NOAA River Forecast Center
-https://geoconnex.us/wwdh/noaa_rfc/WKAO3,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/WKAO3,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/TCCC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/TCCC1,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/LAMC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/LAMC1,cloftus@lincolninst.edu,NOAA River Forecast Center
 https://geoconnex.us/wwdh/noaa_rfc/KRVC1,https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/KRVC1,cloftus@lincolninst.edu,NOAA River Forecast Center


### PR DESCRIPTION
Remove NOAA stations that were removed in the upstream.

This can be generated with the following
```
docker run internetofwater/shacl_validator_grpc_py \
                              generate_geoconnex_csv \
                              --oaf_items_endpoint https://api.wwdh.internetofwater.app/collections/noaa-rfc/items \
                              --description "NOAA River Forecast Center" \
                              --contact_email cloftus@lincolninst.edu \
                              --validate_shacl \
                              --geoconnex_namespace wwdh/noaa_rfc
```