### PR TITLE
Remove link without JSON-LD content for ca-gage-assessment

### DIFF
--- a/namespaces/ca-gage-assessment/ca_gages_pids.csv
+++ b/namespaces/ca-gage-assessment/ca_gages_pids.csv
@@ -1,5 +1,4 @@
 id,target,creator,description
-https://geoconnex.us/ca-gage-assessment, https://gispublic.waterboards.ca.gov/portal/home/item.html?id=32dfb85bd2744487affe6e3475190093, kyle.onda@duke.edu, "California Stream Gages Inventory"
 https://geoconnex.us/ca-gage-assessment/gages/ABJ,https://sb19.linked-data.internetofwater.dev/collections/ca_gages/items/ABJ,kyle.onda@duke.edu,"California Streamgage Network Assessment Catalog, site namedA&B CANAL NR JOHNSTONVILLE"
 https://geoconnex.us/ca-gage-assessment/gages/ACZ,https://sb19.linked-data.internetofwater.dev/collections/ca_gages/items/ACZ,kyle.onda@duke.edu,"California Streamgage Network Assessment Catalog, site namedALHAMBRA CREEK AT D STREET"
 https://geoconnex.us/ca-gage-assessment/gages/AMC,https://sb19.linked-data.internetofwater.dev/collections/ca_gages/items/AMC,kyle.onda@duke.edu,"California Streamgage Network Assessment Catalog, site namedARCADE CREEK AT WINDING WAY"


### PR DESCRIPTION
Remove a link from the sitemap that does not include any JSON-LD content and thus prevents the source from being crawled

See #271  for context