### PR TITLE
Remove dead link that isn't needed

### DIFF
--- a/namespaces/iow/links.csv
+++ b/namespaces/iow/links.csv
@@ -1,7 +1,6 @@
 id,target,creator,description
 https://geoconnex.us/iow/homepage, https://internetofwater.org,konda@lincolninst.edu, Internet Of Water homepage
 https://geoconnex.us/iow/aboutus, https://internetofwater.org/who-we-are/,konda@lincolninst.edu, About us
-https://geoconnex.us/demo, https://geoconnex.internetofwater.dev/demo,konda@lincolninst.edu, geconnex demo
 https://geoconnex.us/iow/sitemap, https://reference.geoconnex.us/stac/sitemap,bwebb@lincolninst.edu, geoconnex sitemap
 https://geoconnex.us/iow/nldi, https://waterdata.usgs.gov/blog/nldi-intro/,konda@lincolninst.edu, nldi shortlink
 https://geoconnex.us/iow/nldi/demo, https://storymaps.arcgis.com/stories/0ecb1aaf143b4e1981dbe30f38fceec5,konda@lincolninst.edu, nldi demo shortlink


### PR DESCRIPTION
Remove a dead link that never resolves and breaks the crawler

As a note, this sitemap seems to provide a lot of info that is already in the docs page. It is unclear if we want to keep this CSV since it has no JSON-LD content and thus can't be queried with SPARQL and is not discoverable / updated like our docs page