### PR TITLE
Remove pregenerated xml files for bulk integrations

### DIFF
--- a/namespaces/bulk/gnis/gnis.xml
+++ b/namespaces/bulk/gnis/gnis.xml
@@ -1,9 +1,0 @@
-<?xml version='1.0' encoding='utf-8'?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-    xmlns:geoconnex="http://geoconnex.us/schemas/sitemap">
-    <url>
-        <loc>internetofwater/gnis_bulk_rdf:latest</loc>
-        <lastmod>2025-02-05T16:39:34Z</lastmod>
-        <geoconnex:type>bulk</geoconnex:type>
-    </url>
-</urlset>

--- a/namespaces/bulk/sciencebase/sciencebase.xml
+++ b/namespaces/bulk/sciencebase/sciencebase.xml
@@ -1,9 +1,0 @@
-<?xml version='1.0' encoding='utf-8'?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-    xmlns:geoconnex="http://geoconnex.us/schemas/sitemap">
-    <url>
-        <loc>ghcr.io/internetofwater/sciencebase_bulk_rdf:latest</loc>
-        <lastmod>2026-04-21</lastmod>
-        <geoconnex:type>bulk</geoconnex:type>
-    </url>
-</urlset>

--- a/namespaces/bulk/usgs_monitoring_locations/usgs_monitoring_locations.xml
+++ b/namespaces/bulk/usgs_monitoring_locations/usgs_monitoring_locations.xml
@@ -1,9 +1,0 @@
-<?xml version='1.0' encoding='utf-8'?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-    xmlns:geoconnex="http://geoconnex.us/schemas/sitemap">
-    <url>
-        <loc>ghcr.io/internetofwater/usgs_monitoring_locations_bulk_rdf:latest</loc>
-        <lastmod>2026-03-31</lastmod>
-        <geoconnex:type>bulk</geoconnex:type>
-    </url>
-</urlset>


### PR DESCRIPTION
Given the latest changes in https://github.com/cgs-earth/sitemap-generator/pull/16 the xml files no longer need to be generated ahead of time. These can be removed and the sitemap generator will make them from the image specified in the metadata.json