### PR TITLE
Tweak which collections to add mainstems to

### DIFF
--- a/namespaces/ref/aiannh/metadata.json
+++ b/namespaces/ref/aiannh/metadata.json
@@ -4,5 +4,5 @@
     "contact_email": "internetofwater@lincolninst.edu",
     "dataset_description": "American Indian/Alaska Native Areas/Hawaiian Home Lands as defined by Bureau of Indian Affairs and Delineated by the U.S. Census Boundary and Annexation Survey served from the Geoconnex reference feature server",
     "dataset_has_html_landing_pages": true,
-    "dataset_documentation_link": "https://reference.geoconnex.us/"
+    "dataset_documentation_link": "https://reference.geoconnex.us/collections/aiannh"
 }

--- a/namespaces/ref/hu02/metadata.json
+++ b/namespaces/ref/hu02/metadata.json
@@ -1,6 +1,6 @@
 {
     "max_request_concurrency": 5,
-    "add_associated_mainstems": true,
+    "add_associated_mainstems": false,
     "contact_email": "internetofwater@lincolninst.edu",
     "dataset_description": "Two-digit Hydrologic Regions from USGS NHDPlus High Resolution served from the Geoconnex reference feature server",
     "dataset_has_html_landing_pages": true,

--- a/namespaces/ref/hu04/metadata.json
+++ b/namespaces/ref/hu04/metadata.json
@@ -1,6 +1,6 @@
 {
     "max_request_concurrency": 5,
-    "add_associated_mainstems": true,
+    "add_associated_mainstems": false,
     "contact_email": "internetofwater@lincolninst.edu",
     "dataset_description": "Four-digit Hydrologic Regions from USGS NHDPlus High Resolution served from the Geoconnex reference feature server",
     "dataset_has_html_landing_pages": true,

--- a/namespaces/ref/hu06/metadata.json
+++ b/namespaces/ref/hu06/metadata.json
@@ -1,6 +1,6 @@
 {
     "max_request_concurrency": 5,
-    "add_associated_mainstems": true,
+    "add_associated_mainstems": false,
     "contact_email": "internetofwater@lincolninst.edu",
     "dataset_description": "Six-digit Hydrologic Regions from USGS NHDPlus High Resolution served from the Geoconnex reference feature server",
     "dataset_has_html_landing_pages": true,

--- a/namespaces/ref/mainstems/metadata.json
+++ b/namespaces/ref/mainstems/metadata.json
@@ -1,6 +1,6 @@
 {
     "max_request_concurrency": 5,
-    "add_associated_mainstems": true,
+    "add_associated_mainstems": false,
     "contact_email": "internetofwater@lincolninst.edu",
     "dataset_description": "Mainstem rivers in the United States served from the Geoconnex reference feature server",
     "dataset_has_html_landing_pages": true,

--- a/namespaces/ref/nat_aq/metadata.json
+++ b/namespaces/ref/nat_aq/metadata.json
@@ -1,6 +1,6 @@
 {
     "max_request_concurrency": 5,
-    "add_associated_mainstems": true,
+    "add_associated_mainstems": false,
     "contact_email": "internetofwater@lincolninst.edu",
     "dataset_description": "National Aquifers of the United States from USGS National Water Information System National Aquifer code list served from the Geoconnex reference feature server",
     "dataset_has_html_landing_pages": true,

--- a/namespaces/ref/states/metadata.json
+++ b/namespaces/ref/states/metadata.json
@@ -1,6 +1,6 @@
 {
     "max_request_concurrency": 5,
-    "add_associated_mainstems": true,
+    "add_associated_mainstems": false,
     "contact_email": "internetofwater@lincolninst.edu",
     "dataset_description": "U.S. States as described by the Profile web pages from the U.S. Census Center for Enterprise Dissemination Services and Consumer Innovation (CEDSCI) served from the Geoconnex reference feature server",
     "dataset_has_html_landing_pages": true,


### PR DESCRIPTION
- don't add mainstem associations to a feature which represents an entire huc02, huc04 huc06, a large principle aquifer, an entire state
- fix a small docs issue for the native american homelands collection