### PR TITLE
Add bulk integration for USGS National geologic map

### DIFF
--- a/namespaces/bulk/usgs/national_geologic_map/metadata.json
+++ b/namespaces/bulk/usgs/national_geologic_map/metadata.json
@@ -1,0 +1,9 @@
+{
+    "contact_email": "cloftus@lincolninst.edu",
+    "dataset_description": "Geospatial Data within the National Geologic Map Database",
+    "dataset_has_html_landing_pages": false,
+    "add_associated_mainstems": false,
+    "source_code_link": "https://github.com/internetofwater/national_geologic_map_bulk_rdf",
+    "dataset_documentation_link": "https://ngmdb.usgs.gov/Prodesc/proddesc_118545.htm",
+    "bulk_container_image": "ghcr.io/internetofwater/usgs_national_geologic_map_bulk_rdf:latest"
+}

--- a/namespaces/bulk/usgs/national_geologic_map/sciencebase.csv
+++ b/namespaces/bulk/usgs/national_geologic_map/sciencebase.csv
@@ -1,0 +1,2 @@
+id,target
+https://geoconnex.us//usgs/national-geologic-map/([-a-zA-Z0-9_]+).*$,https://catalog.geoconnex.us/lookup/$1

--- a/namespaces/bulk/usgs/national_geologic_map/sciencebase.csv
+++ b/namespaces/bulk/usgs/national_geologic_map/sciencebase.csv
@@ -1,2 +1,2 @@
 id,target
-https://geoconnex.us//usgs/national-geologic-map/([-a-zA-Z0-9_]+).*$,https://catalog.geoconnex.us/lookup/$1
+https://geoconnex.us//usgs/national-geologic-map/([-a-zA-Z0-9_]+).*$,https://catalog.geoconnex.us/lookup/https://geoconnex.us/usgs/national-geologic-map/$1


### PR DESCRIPTION
Adds a bulk integration for the usgs national geologic map.

Uses redirect via the [geoconnex catalog service](https://catalog.geoconnex.us/). Note that I may need to tweak this redirect a bit since I just added the `/lookup` endpoint. But this is generally going to be what it is I think unless otherwise have a better redirect target.



